### PR TITLE
Missing client_id parameter in spec

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -56,6 +56,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/QueryState'
         - $ref: '#/components/parameters/ClientCallback'
+        - $ref: '#/components/parameters/ClientId'
       operationId: VerifierAPIStartSIOP
       summary: Initiates the siop flow and returns the 'openid://...' connection string
       responses:


### PR DESCRIPTION
The start siop endpoint doesn't specify the optional parameter client_id in the openapi file but covers it in the implementation -> https://github.com/FIWARE/VCVerifier/blob/main/openapi/api_api.go#L325