### PR TITLE
fix(verifier): keep every holder validation context instead of only the last one

### DIFF
--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -1123,20 +1123,20 @@ outer:
 	return nil
 }
 
-func (v *CredentialVerifier) getHolderValidationContext(clientId string, scope string, credentialTypes []string, holder string) (validationContext []HolderValidationContext, err error) {
-	validationContexts := []HolderValidationContext{}
+func (v *CredentialVerifier) getHolderValidationContext(clientId string, scope string, credentialTypes []string, holder string) (validationContexts []HolderValidationContext, err error) {
+	validationContexts = []HolderValidationContext{}
 	for _, credentialType := range credentialTypes {
 		isEnabled, claim, err := v.credentialsConfig.GetHolderVerification(clientId, scope, credentialType)
 		if err != nil {
 			logging.Log().Warnf("Was not able to get valid holder verification config for client %s, scope %s and type %s. Err: %v", clientId, scope, credentialType, err)
-			return validationContext, err
+			return nil, err
 		}
 		if !isEnabled {
 			continue
 		}
-		validationContexts = append(validationContext, HolderValidationContext{claim: claim, holder: holder})
+		validationContexts = append(validationContexts, HolderValidationContext{claim: claim, holder: holder})
 	}
-	return validationContexts, err
+	return validationContexts, nil
 }
 
 func (v *CredentialVerifier) getTrustRegistriesValidationContext(clientId string, credentialTypes []string, scope string) (verificationContext TrustRegistriesValidationContext, err error) {

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -2195,3 +2195,75 @@ func TestAuthenticationResponse_V5ValidationServices(t *testing.T) {
 		})
 	}
 }
+
+// TestGetHolderValidationContext verifies that one validation context is built per credential type with
+// holder verification enabled. Every enabled type has to survive: dropping one silently skips its holder
+// check in GenerateToken.
+func TestGetHolderValidationContext(t *testing.T) {
+
+	logging.Configure(LOGGING_CONFIG)
+
+	credentialsWithHolderVerification := func(credentials ...configModel.Credential) map[string]map[string]configModel.ScopeEntry {
+		return map[string]map[string]configModel.ScopeEntry{
+			"my-service": {"my-scope": configModel.ScopeEntry{Credentials: credentials}},
+		}
+	}
+	enabled := func(credentialType, claim string) configModel.Credential {
+		return configModel.Credential{Type: credentialType, HolderVerification: configModel.HolderVerification{Enabled: true, Claim: claim}}
+	}
+	disabled := func(credentialType string) configModel.Credential {
+		return configModel.Credential{Type: credentialType, HolderVerification: configModel.HolderVerification{Enabled: false}}
+	}
+
+	type test struct {
+		testName        string
+		mockScopes      map[string]map[string]configModel.ScopeEntry
+		mockError       error
+		credentialTypes []string
+		expectedClaims  []string
+		expectedError   error
+	}
+
+	configError := errors.New("config_error")
+
+	tests := []test{
+		{testName: "Every type with holder verification enabled should get its own context.",
+			mockScopes:      credentialsWithHolderVerification(enabled("TypeA", "subject"), enabled("TypeB", "sub.holder")),
+			credentialTypes: []string{"TypeA", "TypeB"},
+			expectedClaims:  []string{"subject", "sub.holder"}},
+		{testName: "Types with holder verification disabled should be skipped.",
+			mockScopes:      credentialsWithHolderVerification(enabled("TypeA", "subject"), disabled("TypeB"), enabled("TypeC", "otherClaim")),
+			credentialTypes: []string{"TypeA", "TypeB", "TypeC"},
+			expectedClaims:  []string{"subject", "otherClaim"}},
+		{testName: "If no type has holder verification enabled, no context should be created.",
+			mockScopes:      credentialsWithHolderVerification(disabled("TypeA"), disabled("TypeB")),
+			credentialTypes: []string{"TypeA", "TypeB"},
+			expectedClaims:  []string{}},
+		{testName: "If the config cannot be read, the error should be returned.",
+			mockScopes:      credentialsWithHolderVerification(enabled("TypeA", "subject")),
+			mockError:       configError,
+			credentialTypes: []string{"TypeA"},
+			expectedError:   configError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			v := CredentialVerifier{credentialsConfig: mockCredentialConfig{mockScopes: tc.mockScopes, mockError: tc.mockError}}
+
+			validationContexts, err := v.getHolderValidationContext("my-service", "my-scope", tc.credentialTypes, "did:web:holder")
+
+			if tc.expectedError != nil {
+				assert.Equal(t, tc.expectedError, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			claims := []string{}
+			for _, validationContext := range validationContexts {
+				claims = append(claims, validationContext.GetClaim())
+				assert.Equal(t, "did:web:holder", validationContext.GetHolder(), "every context should carry the presented holder")
+			}
+			assert.Equal(t, tc.expectedClaims, claims)
+		})
+	}
+}


### PR DESCRIPTION
getHolderValidationContext appended to validationContext - the named return, which stays nil - instead of to the local validationContexts, so each iteration replaced the slice with a single-element one. With more than one credential type having holder verification enabled, only the last type's context survived and the holder check of every earlier type was silently skipped in GenerateToken.

Drop the near-identical second name that caused it: the named return is now the only slice, and the error paths return nil explicitly.